### PR TITLE
35: [signaling] Remove $disconnect and instead leverage session TTL for cleanup

### DIFF
--- a/.github/workflows/signaling-cd.yml
+++ b/.github/workflows/signaling-cd.yml
@@ -69,7 +69,7 @@ jobs:
       run: |
         aws cloudformation deploy \
           --template-file services/signaling/cloudformation.yaml \
-          --stack-name signaling \
+          --stack-name quick-relay-signaling \
           --capabilities CAPABILITY_NAMED_IAM \
           --parameter-overrides \
             LambdaVersion=${{ env.VERSION }} \

--- a/services/signaling/cloudformation.yaml
+++ b/services/signaling/cloudformation.yaml
@@ -38,10 +38,15 @@ Resources:
       AttributeDefinitions:
         - AttributeName: SessionCode
           AttributeType: S
+        - AttributeName: ExpiresAt
+          AttributeType: N
       KeySchema:
         - AttributeName: SessionCode
           KeyType: HASH
       BillingMode: PAY_PER_REQUEST
+      TimeToLiveSpecification:
+        AttributeName: ExpiresAt
+        Enabled: true
 
   ## IAM Role for the Signaling Lambda
   SignalingLambdaRole:
@@ -104,14 +109,6 @@ Resources:
       RouteKey: "$connect"
       Target: !Sub integrations/${WebSocketIntegration}
 
-  ## $disconnect Route
-  DisconnectRoute:
-    Type: AWS::ApiGatewayV2::Route
-    Properties:
-      ApiId: !Ref QuickRelayWebSocketApi
-      RouteKey: "$disconnect"
-      Target: "integrations/NO-OP"
-
   ## Deployment of the WebSocket API
   WebSocketDeployment:
     Type: AWS::ApiGatewayV2::Deployment
@@ -119,7 +116,6 @@ Resources:
       ApiId: !Ref QuickRelayWebSocketApi
     DependsOn:
       - ConnectRoute
-      - DisconnectRoute
 
   ## WebSocket Stage
   WebSocketStage:

--- a/services/signaling/src/signaling/handler.py
+++ b/services/signaling/src/signaling/handler.py
@@ -2,7 +2,7 @@ import json
 import os
 import boto3
 import random
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from boto3.dynamodb.types import TypeDeserializer
 
 deserializer = TypeDeserializer()
@@ -52,14 +52,16 @@ def create_handler(table):
                     api_gateway.post_to_connection(ConnectionId=connection_id, Data=message)
                     return {"statusCode": 500}
             else:
-                # Create session flow.
+                # In the session creation block
                 new_session_code = generate_short_code()
-                now = datetime.now(timezone.utc).isoformat()
+                now = datetime.now(timezone.utc)
+                expires_at = int((now + timedelta(hours=1)).timestamp())  # Unix epoch time
                 try:
                     table.put_item(Item={
                         "SessionCode": new_session_code,
-                        "CreatedAt": now,
-                        "ConnectionId": connection_id
+                        "CreatedAt": now.isoformat(),
+                        "ConnectionId": connection_id,
+                        "ExpiresAt": expires_at
                     })
                     message = json.dumps({"message": "Session created", "sessionCode": new_session_code})
                     api_gateway.post_to_connection(ConnectionId=connection_id, Data=message)
@@ -69,10 +71,6 @@ def create_handler(table):
                     message = json.dumps({"error": "Error creating session"})
                     api_gateway.post_to_connection(ConnectionId=connection_id, Data=message)
                     return {"statusCode": 500}
-        elif route_key == "$disconnect":
-            # Handle disconnection; for now, just log the disconnection.
-            print(f"Connection {connection_id} disconnected.")
-            return {"statusCode": 200}
         else:
             return {"statusCode": 400, "body": "Invalid route"}
     return handler

--- a/services/signaling/tests/integration/test_integration.py
+++ b/services/signaling/tests/integration/test_integration.py
@@ -117,19 +117,5 @@ class TestWebsocketHandlerWithFakeDynamoDB(unittest.TestCase):
         response = self.handler(event, None)
         self.assertEqual(response["statusCode"], 404)
 
-    def test_disconnect(self):
-        # Simulate a $disconnect event.
-        event = {
-            "requestContext": {
-                "routeKey": "$disconnect",
-                "connectionId": "conn1",
-                "domainName": "example.execute-api.us-east-1.amazonaws.com",
-                "stage": "prod"
-            },
-            "body": None
-        }
-        response = self.handler(event, None)
-        self.assertEqual(response["statusCode"], 200)
-
 if __name__ == '__main__':
     unittest.main()

--- a/services/signaling/tests/unit/test_handler.py
+++ b/services/signaling/tests/unit/test_handler.py
@@ -85,21 +85,6 @@ class TestLambdaHandler(unittest.TestCase):
         self.assertEqual(response["statusCode"], 200)
         self.mock_table.get_item.assert_called_once_with(Key={"SessionCode": session_code})
 
-    @patch("boto3.client")
-    def test_disconnect(self, mock_boto_client):
-        mock_boto_client.return_value = MagicMock()
-        event = {
-            "requestContext": {
-                "routeKey": "$disconnect",
-                "connectionId": "conn1",
-                "domainName": "example.execute-api.us-east-1.amazonaws.com",
-                "stage": "prod"
-            },
-            "body": None
-        }
-        response = self.handler(event, self.context)
-        self.assertEqual(response["statusCode"], 200)
-
     def test_invalid_route(self):
         event = {
             "requestContext": {


### PR DESCRIPTION
Remove $disconnect route, add session TTL for cleanup, rename stack to quick-relay-signaling

closes #35