### PR TITLE
50: [signaling] Bad path to lambda handler

### DIFF
--- a/services/signaling/cloudformation.yaml
+++ b/services/signaling/cloudformation.yaml
@@ -68,7 +68,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: QuickRelayWebsocketSignaling
-      Handler: handler.lambda_handler
+      Handler: signaling.handler.lambda_handler
       Runtime: python3.12
       Role: !GetAtt SignalingLambdaRole.Arn
       Code:


### PR DESCRIPTION
Correct path to reference signaling package prefix

closes #50