### PR TITLE
59: [signaling] $connect cannot be used for additional data exchange, create new init message instead

### DIFF
--- a/services/signaling/cloudformation.yaml
+++ b/services/signaling/cloudformation.yaml
@@ -1,15 +1,14 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >
   Quick Relay WebSocket Signaling Service.
-  This stack provisions the following resources:
-    - A DynamoDB table for storing session data.
-    - A Lambda function (deployed from S3) that handles WebSocket $connect events.
-      The Lambda creates a new session if no "sessionCode" query parameter is provided,
-      or attempts to join an existing session if a sessionCode is provided.
-      It also handles $disconnect events.
-    - An API Gateway WebSocket API with $connect routes.
+  This stack provisions:
+    - A DynamoDB table for storing session data (with TTL for cleanup).
+    - A Lambda function (from S3) that handles WebSocket events:
+        • $connect: Only establishes the connection.
+        • "init": Processes an initial message from the client. If the payload contains no sessionCode, it creates a new session and returns a new code; if it contains a sessionCode, it attempts to join an existing session.
+    - An API Gateway WebSocket API with routes for $connect, "init".
     - A deployment and stage for the WebSocket API.
-
+    
 Parameters:
   S3Bucket:
     Type: String
@@ -56,9 +55,9 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service:
+              Service: 
                 - lambda.amazonaws.com
-            Action:
+            Action: 
               - sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
@@ -107,8 +106,8 @@ Resources:
     Properties:
       Name: QuickRelayWebSocketApi
       ProtocolType: WEBSOCKET
-      # We use query string parameters to determine whether to create or join a session.
-      RouteSelectionExpression: "$request.querystring.sessionCode"
+      # Use the "action" field in the JSON body to route messages.
+      RouteSelectionExpression: "$request.body.action"
 
   ## Integration between the WebSocket API and Lambda (AWS_PROXY)
   WebSocketIntegration:
@@ -118,12 +117,20 @@ Resources:
       IntegrationType: AWS_PROXY
       IntegrationUri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${QuickRelayWebsocketLambdaFunction.Arn}/invocations
 
-  ## $connect Route
+  ## $connect Route (only establishes the connection)
   ConnectRoute:
     Type: AWS::ApiGatewayV2::Route
     Properties:
       ApiId: !Ref QuickRelayWebSocketApi
       RouteKey: "$connect"
+      Target: !Sub integrations/${WebSocketIntegration}
+
+  ## Custom "init" Route for session creation/joining
+  InitRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref QuickRelayWebSocketApi
+      RouteKey: "init"
       Target: !Sub integrations/${WebSocketIntegration}
 
   ## Deployment of the WebSocket API
@@ -133,6 +140,7 @@ Resources:
       ApiId: !Ref QuickRelayWebSocketApi
     DependsOn:
       - ConnectRoute
+      - InitRoute
 
   ## WebSocket Stage
   WebSocketStage:

--- a/services/signaling/src/signaling/handler.py
+++ b/services/signaling/src/signaling/handler.py
@@ -4,6 +4,7 @@ import boto3
 import random
 from datetime import datetime, timezone, timedelta
 from boto3.dynamodb.types import TypeDeserializer
+from botocore.exceptions import ClientError
 
 deserializer = TypeDeserializer()
 
@@ -14,25 +15,35 @@ def deserialize_item(item):
 def create_handler(table):
     """
     Returns a Lambda handler that uses the provided DynamoDB table.
-    This handler is intended for WebSocket API events:
-      - $connect: If query string 'sessionCode' is present, join that session.
-                  Otherwise, create a new session.
-      - $disconnect: Perform cleanup (e.g., remove connection from session).
+    Handles WebSocket events on:
+      - $connect: Just returns 200 (optionally stores connection info).
+      - "init": Handles session creation/join based on the payload.
+      - $disconnect: Logs disconnect.
     """
     def handler(event, context):
         print("Received event:", json.dumps(event, indent=2))
         route_key = event.get("requestContext", {}).get("routeKey")
         connection_id = event.get("requestContext", {}).get("connectionId")
         
-        # Set up API Gateway Management API to post messages back to the client.
+        # Set up API Gateway Management API for sending messages.
         domain_name = event["requestContext"]["domainName"]
         stage = event["requestContext"]["stage"]
         endpoint = f"https://{domain_name}/{stage}"
         api_gateway = boto3.client("apigatewaymanagementapi", endpoint_url=endpoint)
         
         if route_key == "$connect":
-            query_params = event.get("queryStringParameters") or {}
-            session_code = query_params.get("sessionCode")
+            # On $connect, do minimal work. Optionally store connection info.
+            print(f"Connection {connection_id} established.")
+            return {"statusCode": 200}
+        
+        elif route_key == "init":
+            # This route handles session creation/joining.
+            try:
+                body = json.loads(event.get("body") or "{}")
+            except Exception:
+                return {"statusCode": 400, "body": "Invalid JSON in request body"}
+            
+            session_code = body.get("sessionCode")
             if session_code:
                 # Join session flow.
                 try:
@@ -42,7 +53,6 @@ def create_handler(table):
                         api_gateway.post_to_connection(ConnectionId=connection_id, Data=message)
                         return {"statusCode": 404}
                     else:
-                        # Optionally, update the session with the new connection_id.
                         message = json.dumps({"message": "Joined session", "sessionCode": session_code})
                         api_gateway.post_to_connection(ConnectionId=connection_id, Data=message)
                         return {"statusCode": 200}
@@ -52,10 +62,10 @@ def create_handler(table):
                     api_gateway.post_to_connection(ConnectionId=connection_id, Data=message)
                     return {"statusCode": 500}
             else:
-                # In the session creation block
+                # Create session flow.
                 new_session_code = generate_short_code()
                 now = datetime.now(timezone.utc)
-                expires_at = int((now + timedelta(hours=1)).timestamp())  # Unix epoch time
+                expires_at = int((now + timedelta(hours=1)).timestamp())
                 try:
                     table.put_item(Item={
                         "SessionCode": new_session_code,
@@ -81,6 +91,5 @@ def generate_short_code():
 
 # Default wiring: use the table specified by the environment variable TABLE_NAME.
 _default_table = boto3.resource('dynamodb').Table(os.environ.get("TABLE_NAME", "SignalingSessions"))
-# Expose the table as a global for backward compatibility if needed.
 table = _default_table
 lambda_handler = create_handler(_default_table)

--- a/services/signaling/tests/integration/test_integration.py
+++ b/services/signaling/tests/integration/test_integration.py
@@ -1,7 +1,7 @@
 import json
 import os
 import unittest
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 # Fake DynamoDB implementation.
 class FakeDynamoDBTable:
@@ -28,7 +28,7 @@ class FakeDynamoDBTable:
 # A fake API Gateway Management API client for testing.
 class FakeAPIGatewayClient:
     def post_to_connection(self, ConnectionId, Data):
-        # Simply log the call (or do nothing) for tests.
+        # For testing, simply print out the call.
         print(f"Fake post_to_connection: ConnectionId={ConnectionId}, Data={Data}")
         return {}
 
@@ -36,7 +36,7 @@ class FakeAPIGatewayClient:
 def fake_boto_client(service, endpoint_url=None):
     if service == "apigatewaymanagementapi":
         return FakeAPIGatewayClient()
-    # For other services, call the original boto3.client.
+    # Otherwise, return the real boto3 client.
     import boto3
     return boto3.client(service, endpoint_url=endpoint_url)
 
@@ -46,12 +46,12 @@ from signaling.handler import create_handler, generate_short_code
 class TestWebsocketHandlerWithFakeDynamoDB(unittest.TestCase):
     def setUp(self):
         # Set environment variable for TABLE_NAME.
-        os.environ["TABLE_NAME"] = "TestSignalingSessions"
+        os.environ["TABLE_NAME"] = "SignalingSessions"
         # Instantiate our fake DynamoDB table.
         self.fake_table = FakeDynamoDBTable()
         # Create a handler instance using dependency injection.
         self.handler = create_handler(self.fake_table)
-        # Patch boto3.client so that the signaling handler uses our fake API Gateway client.
+        # Patch boto3.client globally to return our fake API Gateway client.
         self.original_boto_client = None
         import boto3
         self.original_boto_client = boto3.client
@@ -63,8 +63,8 @@ class TestWebsocketHandlerWithFakeDynamoDB(unittest.TestCase):
         boto3.client = self.original_boto_client
         del os.environ["TABLE_NAME"]
 
-    def test_connect_create_session(self):
-        # Simulate a $connect event without a sessionCode (should create a session).
+    def test_connect_route(self):
+        # Test the $connect route.
         event = {
             "requestContext": {
                 "routeKey": "$connect",
@@ -76,43 +76,61 @@ class TestWebsocketHandlerWithFakeDynamoDB(unittest.TestCase):
             "body": None
         }
         response = self.handler(event, None)
+        # $connect simply returns 200.
         self.assertEqual(response["statusCode"], 200)
-        # Verify that a session was created in the fake table.
-        self.assertEqual(len(self.fake_table.store), 1)
 
-    def test_connect_join_session_success(self):
-        # Pre-populate the fake table with a session.
-        session_code = "123456"
-        self.fake_table.put_item({
-            "SessionCode": session_code,
-            "CreatedAt": datetime.now(timezone.utc).isoformat(),
-            "ConnectionId": "existingConn"
-        })
-        # Simulate a $connect event with a sessionCode to join.
+    def test_init_create_session(self):
+        # Test the "init" route for session creation (no sessionCode provided).
         event = {
             "requestContext": {
-                "routeKey": "$connect",
+                "routeKey": "init",
                 "connectionId": "conn2",
                 "domainName": "example.execute-api.us-east-1.amazonaws.com",
                 "stage": "prod"
             },
-            "queryStringParameters": {"sessionCode": session_code},
-            "body": None
+            "body": json.dumps({"action": "init"})  # No sessionCode field.
         }
         response = self.handler(event, None)
         self.assertEqual(response["statusCode"], 200)
+        # Verify that a session was created in our fake table.
+        self.assertEqual(len(self.fake_table.store), 1)
+        # Optionally, print out the stored session for debugging.
+        print("Stored sessions:", self.fake_table.store)
 
-    def test_connect_join_session_not_found(self):
-        # Simulate a $connect event with a non-existent sessionCode.
+    def test_init_join_session_success(self):
+        # Pre-populate fake table with a session.
+        session_code = "123456"
+        now = datetime.now(timezone.utc)
+        expires_at = int((now + timedelta(hours=1)).timestamp())
+        self.fake_table.put_item({
+            "SessionCode": session_code,
+            "CreatedAt": now.isoformat(),
+            "ConnectionId": "existingConn",
+            "ExpiresAt": expires_at
+        })
+        # Test the "init" route with a sessionCode to join.
         event = {
             "requestContext": {
-                "routeKey": "$connect",
+                "routeKey": "init",
                 "connectionId": "conn3",
                 "domainName": "example.execute-api.us-east-1.amazonaws.com",
                 "stage": "prod"
             },
-            "queryStringParameters": {"sessionCode": "000000"},
-            "body": None
+            "body": json.dumps({"action": "init", "sessionCode": session_code})
+        }
+        response = self.handler(event, None)
+        self.assertEqual(response["statusCode"], 200)
+
+    def test_init_join_session_not_found(self):
+        # Test the "init" route with a sessionCode that does not exist.
+        event = {
+            "requestContext": {
+                "routeKey": "init",
+                "connectionId": "conn4",
+                "domainName": "example.execute-api.us-east-1.amazonaws.com",
+                "stage": "prod"
+            },
+            "body": json.dumps({"action": "init", "sessionCode": "000000"})
         }
         response = self.handler(event, None)
         self.assertEqual(response["statusCode"], 404)

--- a/services/signaling/tests/unit/test_handler.py
+++ b/services/signaling/tests/unit/test_handler.py
@@ -14,16 +14,16 @@ class TestLambdaHandler(unittest.TestCase):
     def setUp(self):
         self.context = DummyContext()
         self.mock_table = MagicMock()
+        # Create a handler instance using dependency injection.
         self.handler = create_handler(self.mock_table)
 
     @patch("boto3.client")
-    def test_connect_create_session(self, mock_boto_client):
-        # Patch the apigatewaymanagementapi client
+    def test_connect_route(self, mock_boto_client):
+        # Test the $connect route, which should simply return 200.
         mock_api = MagicMock()
         mock_api.post_to_connection.return_value = {}
         mock_boto_client.return_value = mock_api
-        
-        self.mock_table.put_item.return_value = {}
+
         event = {
             "requestContext": {
                 "routeKey": "$connect",
@@ -36,34 +36,41 @@ class TestLambdaHandler(unittest.TestCase):
         }
         response = self.handler(event, self.context)
         self.assertEqual(response["statusCode"], 200)
-        self.mock_table.put_item.assert_called_once()
+        # $connect does not trigger any table operation.
+        self.mock_table.put_item.assert_not_called()
+        self.mock_table.get_item.assert_not_called()
 
     @patch("boto3.client")
-    def test_connect_join_session_not_found(self, mock_boto_client):
+    def test_init_create_session(self, mock_boto_client):
+        # Test the "init" route without a sessionCode in the body, triggering session creation.
         mock_api = MagicMock()
         mock_api.post_to_connection.return_value = {}
         mock_boto_client.return_value = mock_api
         
-        self.mock_table.get_item.return_value = {}
+        # Simulate that table.put_item succeeds.
+        self.mock_table.put_item.return_value = {}
+        # Create an event on the "init" route with no sessionCode.
         event = {
             "requestContext": {
-                "routeKey": "$connect",
-                "connectionId": "conn3",
+                "routeKey": "init",
+                "connectionId": "conn2",
                 "domainName": "example.execute-api.us-east-1.amazonaws.com",
                 "stage": "prod"
             },
-            "queryStringParameters": {"sessionCode": "000000"},
-            "body": None
+            "body": json.dumps({"action": "init"})
         }
         response = self.handler(event, self.context)
-        self.assertEqual(response["statusCode"], 404)
+        self.assertEqual(response["statusCode"], 200)
+        # Verify that put_item was called for session creation.
+        self.mock_table.put_item.assert_called_once()
 
     @patch("boto3.client")
-    def test_connect_join_session_success(self, mock_boto_client):
+    def test_init_join_session_success(self, mock_boto_client):
+        # Test the "init" route with a sessionCode in the body, simulating joining an existing session.
         mock_api = MagicMock()
         mock_api.post_to_connection.return_value = {}
         mock_boto_client.return_value = mock_api
-        
+
         session_code = "123456"
         self.mock_table.get_item.return_value = {
             "Item": {
@@ -73,23 +80,43 @@ class TestLambdaHandler(unittest.TestCase):
         }
         event = {
             "requestContext": {
-                "routeKey": "$connect",
-                "connectionId": "conn2",
+                "routeKey": "init",
+                "connectionId": "conn3",
                 "domainName": "example.execute-api.us-east-1.amazonaws.com",
                 "stage": "prod"
             },
-            "queryStringParameters": {"sessionCode": session_code},
-            "body": None
+            "body": json.dumps({"action": "init", "sessionCode": session_code})
         }
         response = self.handler(event, self.context)
         self.assertEqual(response["statusCode"], 200)
         self.mock_table.get_item.assert_called_once_with(Key={"SessionCode": session_code})
 
+    @patch("boto3.client")
+    def test_init_join_session_not_found(self, mock_boto_client):
+        # Test the "init" route with a sessionCode that does not exist.
+        mock_api = MagicMock()
+        mock_api.post_to_connection.return_value = {}
+        mock_boto_client.return_value = mock_api
+        
+        self.mock_table.get_item.return_value = {}
+        event = {
+            "requestContext": {
+                "routeKey": "init",
+                "connectionId": "conn4",
+                "domainName": "example.execute-api.us-east-1.amazonaws.com",
+                "stage": "prod"
+            },
+            "body": json.dumps({"action": "init", "sessionCode": "000000"})
+        }
+        response = self.handler(event, self.context)
+        self.assertEqual(response["statusCode"], 404)
+
     def test_invalid_route(self):
+        # Test an event with an unknown route.
         event = {
             "requestContext": {
                 "routeKey": "unknown",
-                "connectionId": "conn4",
+                "connectionId": "conn5",
                 "domainName": "example.execute-api.us-east-1.amazonaws.com",
                 "stage": "prod"
             },


### PR DESCRIPTION
Remove session responsibility from $connect route, use new init route instead.

closes #59