### PR TITLE
62: [signaling] Add relay support with new signal action, also enforce two client limit

### DIFF
--- a/services/signaling/cloudformation.yaml
+++ b/services/signaling/cloudformation.yaml
@@ -125,12 +125,28 @@ Resources:
       RouteKey: "$connect"
       Target: !Sub integrations/${WebSocketIntegration}
 
+  ## $connect Route (only establishes the connection)
+  DisconnectRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref QuickRelayWebSocketApi
+      RouteKey: "$disconnect"
+      Target: !Sub integrations/${WebSocketIntegration}
+
   ## Custom "init" Route for session creation/joining
   InitRoute:
     Type: AWS::ApiGatewayV2::Route
     Properties:
       ApiId: !Ref QuickRelayWebSocketApi
       RouteKey: "init"
+      Target: !Sub integrations/${WebSocketIntegration}
+  
+  ## Custom "signal" Route for relaying WebRTC signaling messages
+  SignalRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref QuickRelayWebSocketApi
+      RouteKey: "signal"
       Target: !Sub integrations/${WebSocketIntegration}
 
   ## Deployment of the WebSocket API
@@ -140,7 +156,9 @@ Resources:
       ApiId: !Ref QuickRelayWebSocketApi
     DependsOn:
       - ConnectRoute
+      - DisconnectRoute
       - InitRoute
+      - SignalRoute
 
   ## WebSocket Stage
   WebSocketStage:

--- a/services/signaling/src/signaling/handler.py
+++ b/services/signaling/src/signaling/handler.py
@@ -16,9 +16,12 @@ def create_handler(table):
     """
     Returns a Lambda handler that uses the provided DynamoDB table.
     Handles WebSocket events on:
-      - $connect: Just returns 200 (optionally stores connection info).
-      - "init": Handles session creation/join based on the payload.
-      - $disconnect: Logs disconnect.
+      - $connect: Establishes the connection.
+      - "init": Processes an initial message to create or join a session.
+                If no sessionCode is provided, a new session is created.
+                If a sessionCode is provided, the client is added to the session if it has less than 2 connections.
+      - "signal": Relays signaling messages to other connections in the session.
+      - $disconnect: Logs disconnection.
     """
     def handler(event, context):
         print("Received event:", json.dumps(event, indent=2))
@@ -32,12 +35,12 @@ def create_handler(table):
         api_gateway = boto3.client("apigatewaymanagementapi", endpoint_url=endpoint)
         
         if route_key == "$connect":
-            # On $connect, do minimal work. Optionally store connection info.
+            # $connect: Only establishes the connection.
             print(f"Connection {connection_id} established.")
             return {"statusCode": 200}
         
         elif route_key == "init":
-            # This route handles session creation/joining.
+            # Handles session creation or joining.
             try:
                 body = json.loads(event.get("body") or "{}")
             except Exception:
@@ -53,6 +56,23 @@ def create_handler(table):
                         api_gateway.post_to_connection(ConnectionId=connection_id, Data=message)
                         return {"statusCode": 404}
                     else:
+                        # Extract current ConnectionIds.
+                        session = result["Item"]
+                        # Assume ConnectionIds is stored as a list.
+                        current_ids = session.get("ConnectionIds", [])
+                        if len(current_ids) >= 2:
+                            message = json.dumps({"error": "Session is full"})
+                            api_gateway.post_to_connection(ConnectionId=connection_id, Data=message)
+                            return {"statusCode": 403}
+                        # Otherwise, append the new connection ID.
+                        table.update_item(
+                            Key={"SessionCode": session_code},
+                            UpdateExpression="SET ConnectionIds = list_append(if_not_exists(ConnectionIds, :empty), :conn)",
+                            ExpressionAttributeValues={
+                                ":conn": [connection_id],
+                                ":empty": []
+                            }
+                        )
                         message = json.dumps({"message": "Joined session", "sessionCode": session_code})
                         api_gateway.post_to_connection(ConnectionId=connection_id, Data=message)
                         return {"statusCode": 200}
@@ -70,7 +90,7 @@ def create_handler(table):
                     table.put_item(Item={
                         "SessionCode": new_session_code,
                         "CreatedAt": now.isoformat(),
-                        "ConnectionId": connection_id,
+                        "ConnectionIds": [connection_id],
                         "ExpiresAt": expires_at
                     })
                     message = json.dumps({"message": "Session created", "sessionCode": new_session_code})
@@ -81,6 +101,40 @@ def create_handler(table):
                     message = json.dumps({"error": "Error creating session"})
                     api_gateway.post_to_connection(ConnectionId=connection_id, Data=message)
                     return {"statusCode": 500}
+        
+        elif route_key == "signal":
+            # Relay signaling messages to all connections in the session except the sender.
+            try:
+                body = json.loads(event.get("body") or "{}")
+            except Exception:
+                return {"statusCode": 400, "body": "Invalid JSON in request body"}
+            
+            session_code = body.get("sessionCode")
+            if not session_code:
+                return {"statusCode": 400, "body": "Missing sessionCode in signal message"}
+            
+            try:
+                result = table.get_item(Key={"SessionCode": session_code})
+                if "Item" not in result:
+                    return {"statusCode": 404, "body": "Session not found"}
+                
+                session = result["Item"]
+                connection_ids = session.get("ConnectionIds", [])
+                for cid in connection_ids:
+                    if cid != connection_id:
+                        try:
+                            api_gateway.post_to_connection(ConnectionId=cid, Data=json.dumps(body))
+                        except ClientError as e:
+                            if e.response.get("Error", {}).get("Code") == "GoneException":
+                                print(f"Connection {cid} is gone.")
+                return {"statusCode": 200, "body": "Signal relayed"}
+            except Exception as e:
+                print("Error relaying signal:", str(e))
+                return {"statusCode": 500, "body": "Error relaying signal"}
+        
+        elif route_key == "$disconnect":
+            print(f"Connection {connection_id} disconnected.")
+            return {"statusCode": 200}
         else:
             return {"statusCode": 400, "body": "Invalid route"}
     return handler

--- a/services/signaling/tests/integration/test_integration.py
+++ b/services/signaling/tests/integration/test_integration.py
@@ -9,14 +9,10 @@ class FakeDynamoDBTable:
         self.store = {}
 
     def put_item(self, Item):
-        # Wrap each value as DynamoDB low-level format (e.g., {"S": "value"})
-        wrapped = {}
-        for key, value in Item.items():
-            wrapped[key] = {"S": str(value)}
-        session_code = wrapped.get("SessionCode", {}).get("S")
+        session_code = Item.get("SessionCode")
         if not session_code:
             raise ValueError("Item must have a 'SessionCode' key")
-        self.store[session_code] = wrapped
+        self.store[session_code] = Item
         return {}
 
     def get_item(self, Key):
@@ -25,18 +21,30 @@ class FakeDynamoDBTable:
             return {"Item": self.store[session_code]}
         return {}
 
-# A fake API Gateway Management API client for testing.
-class FakeAPIGatewayClient:
-    def post_to_connection(self, ConnectionId, Data):
-        # For testing, simply print out the call.
-        print(f"Fake post_to_connection: ConnectionId={ConnectionId}, Data={Data}")
+    def update_item(self, Key, UpdateExpression, ExpressionAttributeValues):
+        session_code = Key.get("SessionCode")
+        if session_code not in self.store:
+            raise Exception("Item not found")
+        item = self.store[session_code]
+        current_list = item.get("ConnectionIds", ExpressionAttributeValues.get(":empty"))
+        new_list = current_list + ExpressionAttributeValues.get(":conn")
+        item["ConnectionIds"] = new_list
+        self.store[session_code] = item
         return {}
 
-# Patch boto3.client to return our fake API Gateway client when requested.
+# Fake API Gateway Management API client for testing.
+class FakeAPIGatewayClient:
+    def __init__(self):
+        self.messages = {}
+
+    def post_to_connection(self, ConnectionId, Data):
+        self.messages[ConnectionId] = Data
+        return {}
+
+# Patch boto3.client to return our fake API client.
 def fake_boto_client(service, endpoint_url=None):
     if service == "apigatewaymanagementapi":
         return FakeAPIGatewayClient()
-    # Otherwise, return the real boto3 client.
     import boto3
     return boto3.client(service, endpoint_url=endpoint_url)
 
@@ -45,26 +53,34 @@ from signaling.handler import create_handler, generate_short_code
 
 class TestWebsocketHandlerWithFakeDynamoDB(unittest.TestCase):
     def setUp(self):
-        # Set environment variable for TABLE_NAME.
         os.environ["TABLE_NAME"] = "SignalingSessions"
-        # Instantiate our fake DynamoDB table.
         self.fake_table = FakeDynamoDBTable()
-        # Create a handler instance using dependency injection.
         self.handler = create_handler(self.fake_table)
-        # Patch boto3.client globally to return our fake API Gateway client.
-        self.original_boto_client = None
         import boto3
         self.original_boto_client = boto3.client
-        boto3.client = fake_boto_client
+        self.fake_api_client = FakeAPIGatewayClient()
+        def always_return_fake(service, endpoint_url=None):
+            if service == "apigatewaymanagementapi":
+                return self.fake_api_client
+            return self.original_boto_client(service, endpoint_url=endpoint_url)
+        boto3.client = always_return_fake
+
+        # Pre-populate the fake table with a session that is full (for join full tests)
+        session_code_full = "123456"
+        session_record_full = {
+            "SessionCode": session_code_full,
+            "CreatedAt": datetime.now(timezone.utc).isoformat(),
+            "ConnectionIds": ["conn1", "conn2"],
+            "ExpiresAt": str(int((datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()))
+        }
+        self.fake_table.put_item(Item=session_record_full)
 
     def tearDown(self):
-        # Restore the original boto3.client.
         import boto3
         boto3.client = self.original_boto_client
         del os.environ["TABLE_NAME"]
 
     def test_connect_route(self):
-        # Test the $connect route.
         event = {
             "requestContext": {
                 "routeKey": "$connect",
@@ -76,39 +92,46 @@ class TestWebsocketHandlerWithFakeDynamoDB(unittest.TestCase):
             "body": None
         }
         response = self.handler(event, None)
-        # $connect simply returns 200.
         self.assertEqual(response["statusCode"], 200)
 
-    def test_init_create_session(self):
-        # Test the "init" route for session creation (no sessionCode provided).
+    def test_disconnect_route(self):
         event = {
             "requestContext": {
-                "routeKey": "init",
-                "connectionId": "conn2",
+                "routeKey": "$disconnect",
+                "connectionId": "conn1",
                 "domainName": "example.execute-api.us-east-1.amazonaws.com",
                 "stage": "prod"
             },
-            "body": json.dumps({"action": "init"})  # No sessionCode field.
+            "body": None
         }
         response = self.handler(event, None)
         self.assertEqual(response["statusCode"], 200)
-        # Verify that a session was created in our fake table.
-        self.assertEqual(len(self.fake_table.store), 1)
-        # Optionally, print out the stored session for debugging.
-        print("Stored sessions:", self.fake_table.store)
+
+    def test_init_create_session(self):
+        event = {
+            "requestContext": {
+                "routeKey": "init",
+                "connectionId": "conn_new",
+                "domainName": "example.execute-api.us-east-1.amazonaws.com",
+                "stage": "prod"
+            },
+            "body": json.dumps({"action": "init"})
+        }
+        response = self.handler(event, None)
+        self.assertEqual(response["statusCode"], 200)
+        # Now, the fake table should contain the pre-populated session plus the new one.
+        self.assertEqual(len(self.fake_table.store), 2)
 
     def test_init_join_session_success(self):
-        # Pre-populate fake table with a session.
-        session_code = "123456"
-        now = datetime.now(timezone.utc)
-        expires_at = int((now + timedelta(hours=1)).timestamp())
-        self.fake_table.put_item({
+        # For a successful join, create a session with only one connection.
+        session_code = "654321"
+        session_record = {
             "SessionCode": session_code,
-            "CreatedAt": now.isoformat(),
-            "ConnectionId": "existingConn",
-            "ExpiresAt": expires_at
-        })
-        # Test the "init" route with a sessionCode to join.
+            "CreatedAt": datetime.now(timezone.utc).isoformat(),
+            "ConnectionIds": ["connA"],
+            "ExpiresAt": str(int((datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()))
+        }
+        self.fake_table.put_item(Item=session_record)
         event = {
             "requestContext": {
                 "routeKey": "init",
@@ -120,9 +143,10 @@ class TestWebsocketHandlerWithFakeDynamoDB(unittest.TestCase):
         }
         response = self.handler(event, None)
         self.assertEqual(response["statusCode"], 200)
+        session = self.fake_table.get_item(Key={"SessionCode": session_code})["Item"]
+        self.assertIn("conn3", session.get("ConnectionIds", []))
 
     def test_init_join_session_not_found(self):
-        # Test the "init" route with a sessionCode that does not exist.
         event = {
             "requestContext": {
                 "routeKey": "init",
@@ -134,6 +158,51 @@ class TestWebsocketHandlerWithFakeDynamoDB(unittest.TestCase):
         }
         response = self.handler(event, None)
         self.assertEqual(response["statusCode"], 404)
+
+    def test_init_join_session_full(self):
+        session_code = "123456"  # Pre-populated session with ["conn1", "conn2"]
+        event = {
+            "requestContext": {
+                "routeKey": "init",
+                "connectionId": "conn3",  # Attempting to join as third connection.
+                "domainName": "example.execute-api.us-east-1.amazonaws.com",
+                "stage": "prod"
+            },
+            "body": json.dumps({"action": "init", "sessionCode": session_code})
+        }
+        response = self.handler(event, None)
+        self.assertEqual(response["statusCode"], 403)
+        posted = json.loads(self.fake_api_client.messages.get("conn3", "{}"))
+        self.assertEqual(posted.get("error"), "Session is full")
+
+    def test_signal_route(self):
+        # Simulate a "signal" event from connection "conn1" relaying a signaling message.
+        session_code = "123456"
+        signal_payload = {
+            "action": "signal",
+            "sessionCode": session_code,
+            "type": "offer",
+            "sdp": "<SDP offer data>"
+        }
+        event = {
+            "requestContext": {
+                "routeKey": "signal",
+                "connectionId": "conn1",
+                "domainName": "example.execute-api.us-east-1.amazonaws.com",
+                "stage": "prod"
+            },
+            "body": json.dumps(signal_payload)
+        }
+        response = self.handler(event, None)
+        self.assertEqual(response["statusCode"], 200)
+        # The pre-populated session "123456" has connections ["conn1", "conn2"].
+        # We expect the signal to be relayed only to "conn2".
+        self.assertIn("conn2", self.fake_api_client.messages)
+        relayed = json.loads(self.fake_api_client.messages["conn2"])
+        self.assertEqual(relayed.get("action"), "signal")
+        self.assertEqual(relayed.get("type"), "offer")
+        self.assertEqual(relayed.get("sdp"), "<SDP offer data>")
+        self.assertNotIn("conn1", self.fake_api_client.messages)
 
 if __name__ == '__main__':
     unittest.main()

--- a/services/signaling/tests/unit/test_handler.py
+++ b/services/signaling/tests/unit/test_handler.py
@@ -19,7 +19,7 @@ class TestLambdaHandler(unittest.TestCase):
 
     @patch("boto3.client")
     def test_connect_route(self, mock_boto_client):
-        # Test the $connect route, which should simply return 200.
+        # $connect should simply return 200.
         mock_api = MagicMock()
         mock_api.post_to_connection.return_value = {}
         mock_boto_client.return_value = mock_api
@@ -36,20 +36,17 @@ class TestLambdaHandler(unittest.TestCase):
         }
         response = self.handler(event, self.context)
         self.assertEqual(response["statusCode"], 200)
-        # $connect does not trigger any table operation.
         self.mock_table.put_item.assert_not_called()
         self.mock_table.get_item.assert_not_called()
 
     @patch("boto3.client")
     def test_init_create_session(self, mock_boto_client):
-        # Test the "init" route without a sessionCode in the body, triggering session creation.
+        # Test "init" route to create a new session (no sessionCode provided).
         mock_api = MagicMock()
         mock_api.post_to_connection.return_value = {}
         mock_boto_client.return_value = mock_api
-        
-        # Simulate that table.put_item succeeds.
+
         self.mock_table.put_item.return_value = {}
-        # Create an event on the "init" route with no sessionCode.
         event = {
             "requestContext": {
                 "routeKey": "init",
@@ -61,12 +58,11 @@ class TestLambdaHandler(unittest.TestCase):
         }
         response = self.handler(event, self.context)
         self.assertEqual(response["statusCode"], 200)
-        # Verify that put_item was called for session creation.
         self.mock_table.put_item.assert_called_once()
 
     @patch("boto3.client")
     def test_init_join_session_success(self, mock_boto_client):
-        # Test the "init" route with a sessionCode in the body, simulating joining an existing session.
+        # Test "init" route to join an existing session.
         mock_api = MagicMock()
         mock_api.post_to_connection.return_value = {}
         mock_boto_client.return_value = mock_api
@@ -75,7 +71,8 @@ class TestLambdaHandler(unittest.TestCase):
         self.mock_table.get_item.return_value = {
             "Item": {
                 "SessionCode": {"S": session_code},
-                "CreatedAt": {"S": "2024-04-01T12:00:00"}
+                "CreatedAt": {"S": "2024-04-01T12:00:00"},
+                "ConnectionIds": ["existingConn"]
             }
         }
         event = {
@@ -93,11 +90,11 @@ class TestLambdaHandler(unittest.TestCase):
 
     @patch("boto3.client")
     def test_init_join_session_not_found(self, mock_boto_client):
-        # Test the "init" route with a sessionCode that does not exist.
+        # Test "init" route when the sessionCode is not found.
         mock_api = MagicMock()
         mock_api.post_to_connection.return_value = {}
         mock_boto_client.return_value = mock_api
-        
+
         self.mock_table.get_item.return_value = {}
         event = {
             "requestContext": {
@@ -111,8 +108,62 @@ class TestLambdaHandler(unittest.TestCase):
         response = self.handler(event, self.context)
         self.assertEqual(response["statusCode"], 404)
 
-    def test_invalid_route(self):
-        # Test an event with an unknown route.
+    @patch("boto3.client")
+    def test_signal_valid(self, mock_boto_client):
+        # Test "signal" route where a valid message is relayed.
+        mock_api = MagicMock()
+        mock_api.post_to_connection.return_value = {}
+        mock_boto_client.return_value = mock_api
+
+        # Simulate an existing session with multiple connections.
+        session_code = "123456"
+        self.mock_table.get_item.return_value = {
+            "Item": {
+                "SessionCode": {"S": session_code},
+                "ConnectionIds": [ "conn1", "conn2", "conn3" ]
+            }
+        }
+        # Sender is "conn1" so should relay to "conn2" and "conn3".
+        signal_payload = {
+            "action": "signal",
+            "sessionCode": session_code,
+            "type": "offer",
+            "sdp": "<SDP offer data>"
+        }
+        event = {
+            "requestContext": {
+                "routeKey": "signal",
+                "connectionId": "conn1",
+                "domainName": "example.execute-api.us-east-1.amazonaws.com",
+                "stage": "prod"
+            },
+            "body": json.dumps(signal_payload)
+        }
+        response = self.handler(event, self.context)
+        self.assertEqual(response["statusCode"], 200)
+        # Verify that post_to_connection is called for connections "conn2" and "conn3" but not for "conn1".
+        calls = [call[1]["ConnectionId"] for call in mock_api.post_to_connection.call_args_list]
+        self.assertIn("conn2", calls)
+        self.assertIn("conn3", calls)
+        self.assertNotIn("conn1", calls)
+
+    @patch("boto3.client")
+    def test_disconnect_route(self, mock_boto_client):
+        # Test the $disconnect route.
+        event = {
+            "requestContext": {
+                "routeKey": "$disconnect",
+                "connectionId": "conn1",
+                "domainName": "example.execute-api.us-east-1.amazonaws.com",
+                "stage": "prod"
+            },
+            "body": None
+        }
+        response = self.handler(event, self.context)
+        self.assertEqual(response["statusCode"], 200)
+
+    @patch("boto3.client")
+    def test_invalid_route(self, mock_boto_client):
         event = {
             "requestContext": {
                 "routeKey": "unknown",


### PR DESCRIPTION
Add new signal action route which relays information between clients. This also adds a strict 2 client limit which is enforced in init, preventing more than 2 clients from entering a session.

closes #62