### PR TITLE
76: [web] Move hosting from gh pages to S3

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -1,54 +1,73 @@
-name: Deploy to GitHub Pages
+name: pourtle.com Release Pipeline
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - development
     paths:
       - 'apps/web/**'
 
-permissions:
-  pages: write
-  id-token: write
-
 jobs:
-  build:
+  build-and-deploy:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/web
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
 
+    steps:
+      # Checkout the repository
+      - uses: actions/checkout@v4
+
+      # Setup Node.js (Yarn requires Node.js)
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: 'apps/web/yarn.lock'
 
-      - name: Install Dependencies
-        run: yarn install
+      # Install Yarn dependencies (monorepo)
+      - name: Install Yarn dependencies (monorepo)
+        working-directory: apps/web
+        run: |
+          yarn install --frozen-lockfile
 
-      - name: Build Project
-        run: yarn build
+      # Build React app
+      - name: Build React app
+        working-directory: apps/web
+        run: |
+          yarn build
 
-      - name: Debug - List Build Directory
-        run: ls -la build
-
-      - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v3
+      # Configure AWS credentials
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
         with:
-          path: ${{ github.workspace }}/apps/web/build
-          name: github-pages
-          retention-days: 1
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      # Deploy CloudFormation Stack for pourtle.com
+      - name: Deploy CloudFormation Stack for Beta
+        working-directory: apps/web
+        run: |
+          aws cloudformation deploy \
+            --template-file cloudformation.yaml \
+            --stack-name pourtle-web \
+            --capabilities CAPABILITY_IAM
+
+      # Deploy to S3 for pourtle.com
+      - name: Deploy to S3 for Beta
+        working-directory: apps/web
+        run: aws s3 sync build/ s3://pourtle-web --delete
+
+      # Retrieve CloudFront Distribution ID from CloudFormation Stack Output - Beta
+      - name: Get CloudFront Distribution ID
+        run: |
+          DISTRIBUTION_ID=$(aws cloudformation describe-stacks \
+          --stack-name pourtle-web \
+          --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistributionID'].OutputValue" \
+          --output text)
+          echo "DISTRIBUTION_ID=$DISTRIBUTION_ID" >> $GITHUB_ENV
+
+      # Invalidate CloudFront Cache
+      - name: Invalidate CloudFront Distribution
+        run: aws cloudfront create-invalidation --distribution-id ${{ env.DISTRIBUTION_ID }} --paths "/*"

--- a/apps/web/cloudformation.yaml
+++ b/apps/web/cloudformation.yaml
@@ -1,0 +1,113 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFormation template for pourtle.com
+
+# Parameters:
+  # CertificateArn:
+  #   Type: String
+  #   Description: ARN of the ACM certificate for pourtle.com
+
+Resources:
+  # S3 Bucket for pourtle.com
+  AppBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: pourtle-web
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: index.html
+
+  # S3 Bucket Policy to allow CloudFront access
+  S3BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref AppBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Sub arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${CloudFrontOAI}
+            Action: "s3:GetObject"
+            Resource: !Sub arn:aws:s3:::${AppBucket}/*
+  
+  # CloudFront Origin Access Identity
+  CloudFrontOAI:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: OAI for pourtle.com
+
+  # CloudFront Distribution
+  AppDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        # Aliases:
+        #   - pourtle.com
+        Origins:
+          - DomainName: !GetAtt AppBucket.DomainName
+            Id: AppOrigin
+            S3OriginConfig:
+              OriginAccessIdentity: !Sub origin-access-identity/cloudfront/${CloudFrontOAI}
+        CacheBehaviors:
+          - PathPattern: '/weather/alert/*'
+            TargetOriginId: AppOrigin
+            ViewerProtocolPolicy: redirect-to-https
+            ForwardedValues:
+              QueryString: false
+              Cookies:
+                Forward: none
+            AllowedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+            CachedMethods:
+              - GET
+              - HEAD
+            MinTTL: 300  # TTL 5 minutes
+            MaxTTL: 300
+            DefaultTTL: 300
+        DefaultCacheBehavior:
+          TargetOriginId: AppOrigin
+          ViewerProtocolPolicy: redirect-to-https
+          ForwardedValues:
+            QueryString: true  # Enable query string forwarding if needed
+            Cookies:
+              Forward: none
+          AllowedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+          CachedMethods:
+            - GET
+            - HEAD
+          MinTTL: 0
+          DefaultTTL: 0
+          MaxTTL: 0
+        # ViewerCertificate:
+        #   AcmCertificateArn: !Ref CertificateArn
+        #   SslSupportMethod: sni-only
+        DefaultRootObject: index.html
+        CustomErrorResponses:
+          - ErrorCode: 404
+            ResponsePagePath: /index.html
+            ResponseCode: 200
+            ErrorCachingMinTTL: 0
+          - ErrorCode: 403
+            ResponsePagePath: /index.html
+            ResponseCode: 200
+            ErrorCachingMinTTL: 0
+
+Outputs:
+  BucketName:
+    Description: "Name of the S3 bucket to host the React app"
+    Value: !Ref AppBucket
+
+  CloudFrontDistributionID:
+    Description: "CloudFront Distribution ID"
+    Value: !Ref AppDistribution
+
+  CloudFrontDomainName:
+    Description: "CloudFront Distribution Domain Name"
+    Value: !GetAtt AppDistribution.DomainName

--- a/apps/web/src/components/onboarding/Start.js
+++ b/apps/web/src/components/onboarding/Start.js
@@ -19,8 +19,10 @@ const Start = ({ sessionCode, isLocal = false, requestJoin }) => {
         // ? `http://192.168.68.72:3000/join?session=${sessionCode}`
         // : 'http://192.168.0.2:3000'
         : sessionCode
-            ? `https://quick-relay.com/join?session=${sessionCode}`
-            : 'https://quick-relay.com';
+            ? `https://dv33ucxfhynfc.cloudfront.net/join?session=${sessionCode}`
+            : 'https://dv33ucxfhynfc.cloudfront.net';
+        // ? `https://quick-relay.com/join?session=${sessionCode}`
+        // : 'https://quick-relay.com';
 
     // Handler for copying the universal link.
     const handleCopyLink = useCallback(() => {


### PR DESCRIPTION
Add cloudformation template for the web AWS resources, update pipeline to deploy to S3 and invalidate cloudfront cache, update QR domain to cloudfront temporarily until domain transfer is ready

closes #76