### PR TITLE
84: [web] Update QR to use pourtle.com

### DIFF
--- a/apps/web/src/components/onboarding/Start.js
+++ b/apps/web/src/components/onboarding/Start.js
@@ -16,13 +16,9 @@ const Start = ({ sessionCode, isLocal = false, requestJoin }) => {
         ? sessionCode
             ? `http://192.168.0.2:3000/join?session=${sessionCode}`
             : 'http://192.168.0.2:3000'
-        // ? `http://192.168.68.72:3000/join?session=${sessionCode}`
-        // : 'http://192.168.0.2:3000'
         : sessionCode
-            ? `https://dv33ucxfhynfc.cloudfront.net/join?session=${sessionCode}`
-            : 'https://dv33ucxfhynfc.cloudfront.net';
-        // ? `https://quick-relay.com/join?session=${sessionCode}`
-        // : 'https://quick-relay.com';
+            ? `https://pourtle.com/join?session=${sessionCode}`
+            : 'https://pourtle.com';
 
     // Handler for copying the universal link.
     const handleCopyLink = useCallback(() => {


### PR DESCRIPTION
Use pourtle.com in QR instead of cloudfront domain

closes #84